### PR TITLE
feat: add OpenAI base URL configuration

### DIFF
--- a/packages/api/ai/config.mts
+++ b/packages/api/ai/config.mts
@@ -21,6 +21,7 @@ export async function getModel(): Promise<LanguageModel> {
       const openai = createOpenAI({
         compatibility: 'strict', // strict mode, enabled when using the OpenAI API
         apiKey: config.openaiKey,
+        baseURL: config.aiBaseUrl || undefined,
       });
       return openai(model);
 

--- a/packages/web/src/routes/settings.tsx
+++ b/packages/web/src/routes/settings.tsx
@@ -264,7 +264,9 @@ export function AiSettings({ saveButtonLabel }: AiSettingsProps) {
   const openaiKeySaveEnabled =
     (typeof configOpenaiKey === 'string' && openaiKey !== configOpenaiKey) ||
     ((configOpenaiKey === null || configOpenaiKey === undefined) && openaiKey.length > 0) ||
-    model !== aiModel;
+    model !== aiModel ||
+    (typeof aiBaseUrl === 'string' && baseUrl !== aiBaseUrl) ||
+    ((aiBaseUrl === null || aiBaseUrl === undefined) && baseUrl.length > 0);
 
   const anthropicKeySaveEnabled =
     (typeof configAnthropicKey === 'string' && anthropicKey !== configAnthropicKey) ||
@@ -315,21 +317,31 @@ export function AiSettings({ saveButtonLabel }: AiSettingsProps) {
       </div>
 
       {aiProvider === 'openai' && (
-        <div className="flex gap-2">
-          <Input
-            name="openaiKey"
-            placeholder="openAI API key"
-            type="password"
-            value={openaiKey}
-            onChange={(e) => setOpenaiKey(e.target.value)}
-          />
-          <Button
-            className="px-5"
-            onClick={() => updateConfigContext({ openaiKey, aiModel: model })}
-            disabled={!openaiKeySaveEnabled}
-          >
-            {saveButtonLabel ?? 'Save'}
-          </Button>
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <Input
+              name="openaiKey"
+              placeholder="openAI API key"
+              type="password"
+              value={openaiKey}
+              onChange={(e) => setOpenaiKey(e.target.value)}
+            />
+            <Button
+              className="px-5"
+              onClick={() => updateConfigContext({ openaiKey, aiBaseUrl: baseUrl, aiModel: model })}
+              disabled={!openaiKeySaveEnabled}
+            >
+              {saveButtonLabel ?? 'Save'}
+            </Button>
+          </div>
+          <div className="flex gap-2">
+            <Input
+              name="openaiBaseUrl"
+              placeholder="OpenAI API Base URL (optional)"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+            />
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
# Add OpenAI Base URL Configuration

This PR adds support for configuring a custom OpenAI base URL alongside the API key in the settings UI.

## Changes
- Add input field for OpenAI base URL in settings UI
- Update OpenAI client to use custom base URL when provided
- Maintain backward compatibility with undefined fallback
- Update save button to handle base URL changes

## Testing Status
⚠️ Local testing was not possible due to package resolution issues with @srcbook/shared. The changes have been kept minimal and focused on the feature implementation. CI will verify the changes in a controlled environment.

## Notes
- The base URL field is optional and only affects the OpenAI provider
- Existing configurations without a base URL will continue to work as before
- The UI updates maintain consistency with the existing settings layout

Link to Devin run: https://app.devin.ai/sessions/3e30509dcf3a4c138f030943291460c6
